### PR TITLE
Used recommended Kubernetes labels

### DIFF
--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -55,11 +55,11 @@ Now you can create Tomcat instances with CRs (see examples above).
 ## EventSources
 The TomcatController is listening to events about Deployments created by the TomcatOperator by registering a
 DeploymentEventSource with the EventSourceManager. The DeploymentEventSource will in turn register a watch on
-all Deployments managed by the Controller (identified by the `managed-by` label). 
+all Deployments managed by the Controller (identified by the `app.kubernetes.io/managed-by` label). 
 When an event from a Deployment is received we have to identify which Tomcat object does the Deployment
 belong to. This is done when the DeploymentEventSource creates the DeploymentEvent.
 
-The TomcatController has to take care of setting the `managed-by` label on the Deployment so the 
+The TomcatController has to take care of setting the `app.kubernetes.io/managed-by` label on the Deployment so the 
 DeploymentEventSource can watch the right Deployments.
 The TomcatController also has to set `ownerReference` on the Deployment so later the DeploymentEventSource can 
 identify which Tomcat does the Deployment belong to. This is necessary so the frameowork can call the Controller

--- a/tomcat/src/main/java/io/javaoperatorsdk/operator/sample/DeploymentEventSource.java
+++ b/tomcat/src/main/java/io/javaoperatorsdk/operator/sample/DeploymentEventSource.java
@@ -31,7 +31,7 @@ public class DeploymentEventSource extends AbstractEventSource implements Watche
         .apps()
         .deployments()
         .inAnyNamespace()
-        .withLabel("managed-by", "tomcat-operator")
+        .withLabel("app.kubernetes.io/managed-by", "tomcat-operator")
         .watch(this);
   }
 

--- a/tomcat/src/main/java/io/javaoperatorsdk/operator/sample/TomcatController.java
+++ b/tomcat/src/main/java/io/javaoperatorsdk/operator/sample/TomcatController.java
@@ -93,8 +93,8 @@ public class TomcatController implements ResourceController<Tomcat> {
       Deployment deployment = loadYaml(Deployment.class, "deployment.yaml");
       deployment.getMetadata().setName(tomcat.getMetadata().getName());
       deployment.getMetadata().setNamespace(ns);
-      deployment.getMetadata().getLabels().put("created-by", tomcat.getMetadata().getName());
-      deployment.getMetadata().getLabels().put("managed-by", "tomcat-operator");
+      deployment.getMetadata().getLabels().put("app.kubernetes.io/part-of", tomcat.getMetadata().getName());
+      deployment.getMetadata().getLabels().put("app.kubernetes.io/managed-by", "tomcat-operator");
       // set tomcat version
       deployment
           .getSpec()

--- a/tomcat/src/main/resources/io/javaoperatorsdk/operator/sample/deployment.yaml
+++ b/tomcat/src/main/resources/io/javaoperatorsdk/operator/sample/deployment.yaml
@@ -3,8 +3,8 @@ kind: Deployment
 metadata:
   name: ""
   labels:
-    created-by: ""
-    managed-by: "" # used for filtering of Deployments created by the controller
+    app.kubernetes.io/part-of: ""
+    app.kubernetes.io/managed-by: "" # used for filtering of Deployments created by the controller
   ownerReferences: # used for finding which Tomcat does this Deployment belong to
     - apiVersion: apps/v1
       kind: Tomcat


### PR DESCRIPTION
This trivial PR changes the labels applied by the operator on the Deployment in order to use the recommended Kubernetes ones as described here https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/